### PR TITLE
Implement basic testing framework with Catch2

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Set up of the Catch2 Testing framework
+#
+
+# Add executables to this variable
+set(TEST_SOURCE
+    CatchMain.cpp Test_Catch.cpp
+)
+# Add subdirectories 
+
+# add_subdirectory(parser)
+
+###############################################
+# Nothing should have to be changed from here
+###############################################
+message(STATUS "Tests are included")
+
+# link Catch2 library
+add_subdirectory(extern/Catch2)
+add_executable(tests ${TEST_SOURCE})
+target_link_libraries(tests Catch2::Catch2)
+
+# add Catch2 cmake scripts to module path to allow automatic
+# test discovery
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/test/extern/Catch2/contrib/")
+message(STATUS "CMAKE_MODULE_PATH = " ${CMAKE_MODULE_PATH})
+include(CTest)
+include(Catch)
+catch_discover_tests(tests)

--- a/test/CatchMain.cpp
+++ b/test/CatchMain.cpp
@@ -1,0 +1,12 @@
+
+/**
+ * @file CatchMain.cpp
+ * @author Abraham Bherer-Constant
+ * @date 2021/01/12
+ * @brief Make use of Catch2 default main definition
+ *
+ * This file should not contain any tests
+ */
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch.hpp>

--- a/test/Test_Catch.cpp
+++ b/test/Test_Catch.cpp
@@ -1,0 +1,13 @@
+
+/**
+ * @file Test_Catch.cpp
+ * @author Abraham Bherer-Constant
+ * @date 2021/01/12
+ * @brief Trivial test to check that Catch is correctly working
+ *
+ * This file should not contain any other tests, but it can be
+ * used as a template for new test files
+ */
+#include <catch2/catch.hpp>
+
+TEST_CASE("Catch is correctly working") { REQUIRE(1 == 1); }


### PR DESCRIPTION
The source code for Catch2 v2.13.4 is currently included in the repo.
This is simpler for new users since they do not have to handle git
submodules.

The header file only approach has not been used since it is
unrecommended by the Catch2 documentation.

V2 is used since the documentation is incomplete for V3.